### PR TITLE
Rate limiting, CORS, scraper safety, logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,20 +4,36 @@ from flask_login import LoginManager, UserMixin, login_user, logout_user, login_
 from flask_jwt_extended import JWTManager, create_access_token, jwt_required, get_jwt_identity
 from werkzeug.security import generate_password_hash, check_password_hash
 from flask_cors import CORS
+from flask_limiter import Limiter
+from flask_limiter.util import get_remote_address
+import logging
 import numpy as np
 import dateparser
 import math
 import re
 import json
 import os
+import sentry_sdk
+from sentry_sdk.integrations.flask import FlaskIntegration
 from scraper import get_gameweek_teams, get_results, get_round_scores, get_next_start_time
 from datetime import datetime,timedelta
 import smtplib
 from email.mime.multipart import MIMEMultipart
 from email.mime.text import MIMEText
 from itsdangerous import URLSafeTimedSerializer
-import smtplib
 import pandas as pd
+
+# Logging
+logging.basicConfig(
+    level=logging.INFO,
+    format='%(asctime)s %(levelname)s %(name)s: %(message)s',
+)
+logger = logging.getLogger('golden_picks')
+
+# Sentry (error monitoring) — set SENTRY_DSN env var on Render to enable
+sentry_dsn = os.environ.get('SENTRY_DSN')
+if sentry_dsn:
+    sentry_sdk.init(dsn=sentry_dsn, integrations=[FlaskIntegration()], traces_sample_rate=0.1)
 
 TEAM_MAPS = {"Burnley":"BUR","Sunderland":"SUN","Leeds": "LEE","Leicester": "LEI", "ManchesterCity":"MCI","Liverpool":"LIV","WestHam":"WHU","Chelsea":"CHE","Ipswich":"IPS","Arsenal":"ARS","Brentford":"BRE","CrystalPalace":"CRY","Southampton":"SOU","Tottenham":"TOT","Wolves":"WOL","AstonVilla":"AVL","Brighton":"BHA","Fulham":"FUL","Bournemouth":"BOU","Newcastle":"NEW","ManchesterUtd":"MUN","Everton":"EVE","Nottingham":"NFO"}
 REVERSE_TEAM_MAPS = {value:key for key,value in TEAM_MAPS.items()}
@@ -27,9 +43,14 @@ TEAM_MAPS_2 = {"Burnley":"Burnley","Sunderland":"Sunderland","Leeds": "Leeds","L
 
 app = Flask(__name__)
 app.config.from_object('config.Config')
-CORS(app, resources={r"/*": {"origins": "*"}})
+CORS(app, resources={r"/*": {"origins": [
+    "https://premier-league-predictions-2.onrender.com",
+    "http://localhost:*",
+    "http://127.0.0.1:*",
+]}})
 
 jwt = JWTManager(app)
+limiter = Limiter(get_remote_address, app=app, default_limits=["200 per minute"], storage_uri="memory://")
 s = URLSafeTimedSerializer(app.config['SECRET_KEY'])
 
 db = SQLAlchemy(app)
@@ -534,8 +555,8 @@ def signup():
 
 @app.route('/keep-alive')
 def keep_alive():
-    
-    gameweek_teams = GameWeekTeams.query.first()  # Retrieve the first record
+
+    gameweek_teams = GameWeekTeams.query.first()
     if not gameweek_teams:
         return "I'm alive!", 200
 
@@ -546,22 +567,23 @@ def keep_alive():
 
     if now > end_time:
         try:
-    
-            row = GameWeekTeams.query.get(1)        
-            #gameweek_teams = get_gameweek_teams()      # fetch the first row (id=1)
+            row = GameWeekTeams.query.get(1)
             if not row:
                 raise RuntimeError("Row id=1 not found")
 
             row.end_time = datetime.now() + timedelta(days=100)
             db.session.commit()
+            logger.info("End time passed — updating scores and generating new teams")
             update_scores()
             generate_teams_auto()
             return "updated scores",200
-        except AttributeError: 
-            return "failed updating scores", 200
+        except Exception as e:
+            logger.error(f"keep-alive score update failed: {e}", exc_info=True)
+            return f"failed updating scores: {e}", 500
 
     if now > start_time - pd.Timedelta(minutes=30):
-        lock_team_choices()  # Call the lock function if the condition is met
+        logger.info("Lock window reached — locking team choices")
+        lock_team_choices()
         return "team choices locked", 200
         
     if 0 < (email_time - now).total_seconds() < 305:
@@ -578,9 +600,11 @@ def keep_alive():
             round = len(json.loads(admin.previous_results)) +1 
     try:
         results = get_round_scores(round)
-        add_results_to_gameweek(results)
-    except AttributeError:
-        pass
+        if results:
+            add_results_to_gameweek(results)
+            logger.info(f"Updated live results for round {round}: {len(results)} fixtures")
+    except Exception as e:
+        logger.warning(f"Failed to fetch live results for round {round}: {e}")
 
     return "I'm alive!", 200
 
@@ -631,6 +655,7 @@ def admin():
 
 
 @app.route('/login', methods=['GET', 'POST'])
+@limiter.limit("10 per minute")
 def login():
     if request.method == 'POST':
         username = request.form['username']
@@ -864,6 +889,7 @@ def create_league():
 
 
 @app.route('/registerIOS', methods=['POST'])
+@limiter.limit("5 per minute")
 def registerIOS():
     data = request.json
     username = data.get('username')
@@ -923,6 +949,7 @@ def createleagueIOS():
 
 
 @app.route('/loginIOS', methods=['POST'])
+@limiter.limit("10 per minute")
 def loginIOS():
     data = request.json
     identifier = data.get('username')
@@ -1588,6 +1615,7 @@ def register_leagueIOS():
 
 
 @app.route('/send_reset_emailIOS', methods=['POST'])
+@limiter.limit("3 per minute")
 def send_reset_emailIOS():
     data = request.json
     email = data.get('email')

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,3 +14,5 @@ regex==2024.11.6
 dateparser==1.2.1
 tzlocal==5.3.1
 flask-cors==3.0.10
+Flask-Limiter==3.5.0
+sentry-sdk[flask]==1.40.0

--- a/scraper.py
+++ b/scraper.py
@@ -2,17 +2,23 @@ import requests
 from bs4 import BeautifulSoup
 import pandas as pd
 import dateparser
+import logging
+
+logger = logging.getLogger('golden_picks.scraper')
+
 TEAM_MAPS = {"Burnley":"BUR","Sunderland":"SUN","Leeds": "LEE","Leicester": "LEI", "ManchesterCity":"MCI","Liverpool":"LIV","WestHam":"WHU","Chelsea":"CHE","Ipswich":"IPS","Arsenal":"ARS","Brentford":"BRE","CrystalPalace":"CRY","Southampton":"SOU","Tottenham":"TOT","Wolves":"WOL","AstonVilla":"AVL","Brighton":"BHA","Fulham":"FUL","Bournemouth":"BOU","Newcastle":"NEW","ManchesterUtd":"MUN","Everton":"EVE","Nottingham":"NFO"}
 
-def fetch_data_fixtures(soup, round ):
-    table_matches = soup.find('table')#, attrs={'class':'table-main js-tablebanner-t js-tablebanner-ntb'})
+def fetch_data_fixtures(soup, round):
+    table_matches = soup.find('table')
+    if table_matches is None:
+        logger.error("No table found on fixtures page")
+        return pd.DataFrame(columns=['Date','Match','1','X','2'])
     data = []
     rows = table_matches.find_all('tr')
-    data=[]
     keep_searching = False
     start_searching = False
     if round is None:
-        round = 1 #This needs to be changed for testing to most recent round
+        round = 1
     for row in rows:
         if 'Round' in row.text and str(round)+'.' in row.text:
             start_searching = True
@@ -24,16 +30,13 @@ def fetch_data_fixtures(soup, round ):
             utils = []
             cols = row.find_all('td')
             utils = [button['data-odd'] for button in row.find_all('button')]
-            # Extract fixture name
             for element in cols:
                 try:
-                    # Store the odds that win and didnt win
                     if 'data-odd' in element.attrs:
                         pass
                     else:
                         utils.append(element.span.span.span['data-odd'])
                 except:
-                    # Store the text
                     utils.append(element.text)
             if len(utils) == 10:
                 data.append(utils)
@@ -41,7 +44,6 @@ def fetch_data_fixtures(soup, round ):
     return df[['Date','Match','1','X','2']]
 
 
-# Function to handle both cases
 def process_date(date_str):
     dt = dateparser.parse(
         date_str,
@@ -51,7 +53,7 @@ def process_date(date_str):
         }
     )
     if dt is None:
-        return None    
+        return None
     return pd.Timestamp(dt)
 
 def get_teams(match):
@@ -59,63 +61,73 @@ def get_teams(match):
     return home,away
 
 def get_next_start_time(round):
-    round = round
-    URL = "https://www.betexplorer.com/football/england/premier-league/fixtures/"
-    #URL = "https://www.betexplorer.com/football/sweden/allsvenskan/fixtures/"
-    response = requests.get(URL)
+    try:
+        URL = "https://www.betexplorer.com/football/england/premier-league/fixtures/"
+        response = requests.get(URL, timeout=15)
+        response.raise_for_status()
 
-    soup = BeautifulSoup(response.text, 'html.parser')
-    data = fetch_data_fixtures(soup,round)
+        soup = BeautifulSoup(response.text, 'html.parser')
+        data = fetch_data_fixtures(soup, round)
 
-    data['Date'] = data['Date'].apply(process_date)
-    first_game = data['Date'].min() - pd.Timedelta(minutes=90)
-    return first_game
+        if data.empty:
+            logger.warning(f"No fixture data for round {round}")
+            return None
+
+        data['Date'] = data['Date'].apply(process_date)
+        first_game = data['Date'].min() - pd.Timedelta(minutes=90)
+        return first_game
+    except Exception as e:
+        logger.error(f"get_next_start_time failed for round {round}: {e}")
+        return None
 
 def get_gameweek_teams(round):
-    print (1111111)
-    round = round
-    URL = "https://www.betexplorer.com/football/england/premier-league/fixtures/"
-    #URL = "https://www.betexplorer.com/football/sweden/allsvenskan/fixtures/"
-    response = requests.get(URL)
+    try:
+        URL = "https://www.betexplorer.com/football/england/premier-league/fixtures/"
+        response = requests.get(URL, timeout=15)
+        response.raise_for_status()
 
-    soup = BeautifulSoup(response.text, 'html.parser')
-    data = fetch_data_fixtures(soup,round)
+        soup = BeautifulSoup(response.text, 'html.parser')
+        data = fetch_data_fixtures(soup, round)
 
-    data['Date'] = data['Date'].apply(process_date)
-    first_game = data['Date'].min() - pd.Timedelta(minutes=90)
-    last_game = data['Date'].max() + pd.Timedelta(minutes=240)
+        if data.empty:
+            logger.error(f"No fixture data for round {round} — returning empty")
+            return {}, {}, None, None
 
+        data['Date'] = data['Date'].apply(process_date)
+        first_game = data['Date'].min() - pd.Timedelta(minutes=90)
+        last_game = data['Date'].max() + pd.Timedelta(minutes=240)
 
-    data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
-    data['home'] = data['home1'] + '_' + data['away1'] +'_H'
-    data['away'] = data['away1'] + '_' + data['home1'] +'_A'
-    data['home']=data['home'].str.replace(' ','')
-    data['away']=data['away'].str.replace(' ','')
-    
-    odds = {}
-    ex_points = {}
-    for _,row in data.iterrows():
-        win = 1/float(row['1'])
-        draw = 1/ float(row['X'])
-        lose = 1/float(row['2'])
-        sum = (win + draw+lose)
-        win2 = win/sum
-        draw2 = draw/sum
-        lose2 = lose/sum
+        data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
+        data['home'] = data['home1'] + '_' + data['away1'] +'_H'
+        data['away'] = data['away1'] + '_' + data['home1'] +'_A'
+        data['home']=data['home'].str.replace(' ','')
+        data['away']=data['away'].str.replace(' ','')
 
-        odds[row['home']]=float(row['1'])
-        odds[row['away']]= float(row['2'])
+        odds = {}
+        ex_points = {}
+        for _,row in data.iterrows():
+            win = 1/float(row['1'])
+            draw = 1/ float(row['X'])
+            lose = 1/float(row['2'])
+            total = (win + draw+lose)
+            win2 = win/total
+            draw2 = draw/total
+            lose2 = lose/total
 
-        ex_points[row['home']] = 3*win2 + draw2
-        ex_points[row['away']] = 3*lose2 + draw2
+            odds[row['home']]=float(row['1'])
+            odds[row['away']]= float(row['2'])
 
-    print (ex_points)
+            ex_points[row['home']] = 3*win2 + draw2
+            ex_points[row['away']] = 3*lose2 + draw2
 
-    sorted_odds= dict(sorted(odds.items(), key=lambda item: float(item[1])))
-    ordered_list = list(sorted_odds.keys())
-    L =  (20-len(ordered_list))/2
-    return {ordered_list[i].strip():20-i-L for i in range(len(ordered_list))},ex_points, first_game, last_game
-
+        sorted_odds= dict(sorted(odds.items(), key=lambda item: float(item[1])))
+        ordered_list = list(sorted_odds.keys())
+        L =  (20-len(ordered_list))/2
+        logger.info(f"Scraped round {round}: {len(ordered_list)} teams")
+        return {ordered_list[i].strip():20-i-L for i in range(len(ordered_list))},ex_points, first_game, last_game
+    except Exception as e:
+        logger.error(f"get_gameweek_teams failed for round {round}: {e}")
+        return {}, {}, None, None
 
 
 def get_result_points_home(result_str):
@@ -127,62 +139,70 @@ def get_result_points_away(result_str):
     return int(away) - int(home)
 
 
-
 def fetch_data_results(soup):
-    table_matches = soup.find('table')#, attrs={'class':'table-main js-tablebanner-t js-tablebanner-ntb'})
+    table_matches = soup.find('table')
+    if table_matches is None:
+        logger.error("No table found on results page")
+        return pd.DataFrame(columns=["Match","result","odds","date"])
     data = []
     rows = table_matches.find_all('tr')
-    data=[]
     for row in rows:
         utils = []
         cols = row.find_all('td')
         utils = [button['data-odd'] for button in row.find_all('button')]
-        # Extract fixture name
         for element in cols:
             try:
-                # Store the odds that win and didnt win
                 if 'data-odd' in element.attrs:
                     pass
                 else:
                     utils.append(element.span.span.span['data-odd'])
             except:
-                # Store the text
                 utils.append(element.text)
 
         if len(utils) == 4:
             data.append(utils)
 
-
     df = pd.DataFrame(data,columns=["Match","result","odds","date"])
     return df
 
 def get_results():
-    URL = "https://www.betexplorer.com/football/england/premier-league/results/"
-    response = requests.get(URL)
-    soup = BeautifulSoup(response.text, 'html.parser')
+    try:
+        URL = "https://www.betexplorer.com/football/england/premier-league/results/"
+        response = requests.get(URL, timeout=15)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'html.parser')
 
-    data = fetch_data_results(soup)
-    data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
-    data['home'] = data['home1'] + '_' + data['away1'] +'_H'
-    data['away'] = data['away1'] + '_' + data['home1'] +'_A'
-    data['home']=data['home'].str.replace(' ','')
-    data['away']=data['away'].str.replace(' ','')
+        data = fetch_data_results(soup)
+        if data.empty:
+            logger.warning("No results data found")
+            return {}
 
-    data['points_home']=data['result'].apply(get_result_points_home).apply(pd.Series)
-    data['points_away']=data['result'].apply(get_result_points_away).apply(pd.Series)
-    points = {}
-    for _,row in data.iterrows():
-        points[row['home']]=int(row['points_home'])
-        points[row['away']]= float(row['points_away'])
+        data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
+        data['home'] = data['home1'] + '_' + data['away1'] +'_H'
+        data['away'] = data['away1'] + '_' + data['home1'] +'_A'
+        data['home']=data['home'].str.replace(' ','')
+        data['away']=data['away'].str.replace(' ','')
 
-    return points
+        data['points_home']=data['result'].apply(get_result_points_home).apply(pd.Series)
+        data['points_away']=data['result'].apply(get_result_points_away).apply(pd.Series)
+        points = {}
+        for _,row in data.iterrows():
+            points[row['home']]=int(row['points_home'])
+            points[row['away']]= float(row['points_away'])
+
+        return points
+    except Exception as e:
+        logger.error(f"get_results failed: {e}")
+        return {}
 
 
 def fetch_data_scores(soup, round):
-    table_matches = soup.find('table')#, attrs={'class':'table-main js-tablebanner-t js-tablebanner-ntb'})
+    table_matches = soup.find('table')
+    if table_matches is None:
+        logger.error("No table found on results page for scores")
+        return pd.DataFrame(columns=["Match","result","odds","date"])
     data = []
     rows = table_matches.find_all('tr')
-    data=[]
     total_rounds = 0
     for row in rows:
         if 'Round' in row.text and str(round -1)+'.' in row.text:
@@ -192,47 +212,45 @@ def fetch_data_scores(soup, round):
         utils = []
         cols = row.find_all('td')
         utils = [button['data-odd'] for button in row.find_all('button')]
-        # Extract fixture name
         for element in cols:
             try:
-                # Store the odds that win and didnt win
                 if 'data-odd' in element.attrs:
                     pass
                 else:
                     utils.append(element.span.span.span['data-odd'])
             except:
-                # Store the text
                 utils.append(element.text)
 
         if len(utils) == 4:
             data.append(utils)
 
-
     df = pd.DataFrame(data,columns=["Match","result","odds","date"])
     return df
 
 def get_round_scores(round):
-    URL = "https://www.betexplorer.com/football/england/premier-league/results/"
-    response = requests.get(URL)
-    soup = BeautifulSoup(response.text, 'html.parser')
-    round = round
-    data = fetch_data_scores(soup, round)
-    if len(data) == 0:
+    try:
+        URL = "https://www.betexplorer.com/football/england/premier-league/results/"
+        response = requests.get(URL, timeout=15)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, 'html.parser')
+        data = fetch_data_scores(soup, round)
+        if data.empty:
+            return []
+        data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
+        data['home'] = data['home1'] + '_' + data['away1'] +'_H'
+        data['away'] = data['away1'] + '_' + data['home1'] +'_A'
+        data['home']=data['home'].str.replace(' ','')
+        data['away']=data['away'].str.replace(' ','')
+
+        scores = []
+        for _,row in data.iterrows():
+            h,a = row.result.split(':')
+            try:
+                score = {"team1": TEAM_MAPS[row['home1'].replace(' ','')], "team2": TEAM_MAPS[row['away1'].replace(' ','')], "score1": int(h), "score2": int(a)}
+            except KeyError:
+                score = {"team1": row['home1'].replace(' ',''), "team2": row['away1'].replace(' ',''), "score1": int(h), "score2": int(a)}
+            scores += [score]
+        return scores
+    except Exception as e:
+        logger.error(f"get_round_scores failed for round {round}: {e}")
         return []
-    data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
-    data['home'] = data['home1'] + '_' + data['away1'] +'_H'
-    data['away'] = data['away1'] + '_' + data['home1'] +'_A'
-    data['home']=data['home'].str.replace(' ','')
-    data['away']=data['away'].str.replace(' ','')
-
-
-    scores = []
-    for _,row in data.iterrows():
-        h,a = row.result.split(':')
-        try:
-            score = {"team1": TEAM_MAPS[row['home1'].replace(' ','')], "team2": TEAM_MAPS[row['away1'].replace(' ','')], "score1": int(h), "score2": int(a)}
-        except KeyError:
-            score = {"team1": row['home1'].replace(' ',''), "team2": row['away1'].replace(' ',''), "score1": int(h), "score2": int(a)}
-
-        scores += [score]
-    return scores


### PR DESCRIPTION
## Summary
- **Rate limiting**: login 10/min, register 5/min, password reset 3/min
- **CORS**: locked from `*` to Render domain + localhost
- **Scraper**: all functions wrapped in try/catch with safe defaults, 15s request timeouts, null checks on HTML parsing
- **Logging**: Python logging configured, key events logged (score updates, team locking, scraper failures)
- **Sentry**: integration added (set `SENTRY_DSN` env var to enable)
- **keep-alive**: catches all exceptions (was only catching `AttributeError`), returns 500 on failure

## Test plan
- [ ] Login works normally (under 10 attempts/min)
- [ ] 11th login attempt within 1 minute returns 429
- [ ] keep-alive returns 200
- [ ] If scraper is unreachable, keep-alive still returns (doesn't crash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)