### PR TITLE
Add /support route for App Store compliance

### DIFF
--- a/app.py
+++ b/app.py
@@ -1983,6 +1983,11 @@ def generate_reset_token(user):
     token = jwt.encode(payload, app.config['SECRET_KEY'], algorithm="HS256")
     return token
 
+@app.route('/support', methods=['GET'])
+def support():
+    return render_template('support.html')
+
+
 if __name__ == '__main__':
     #create_database()
     port = int(os.environ.get("PORT", 5000))

--- a/templates/support.html
+++ b/templates/support.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Golden Picks — Support</title>
+    <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <style>
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Arial, sans-serif;
+            background: #1E1E2F;
+            color: #F5F5F5;
+            line-height: 1.6;
+            padding: 24px;
+        }
+        .container {
+            max-width: 760px;
+            margin: 0 auto;
+            background: #2B363B;
+            padding: 32px 36px;
+            border-radius: 12px;
+            box-shadow: 0 6px 24px rgba(0,0,0,0.4);
+        }
+        h1 {
+            color: #E0C36F;
+            margin-bottom: 8px;
+        }
+        h2 {
+            color: #E0C36F;
+            margin-top: 32px;
+            font-size: 1.25rem;
+            border-bottom: 1px solid #3a464c;
+            padding-bottom: 6px;
+        }
+        a {
+            color: #E0C36F;
+        }
+        a:hover {
+            color: #f0d488;
+        }
+        .lede {
+            color: #9A9AB0;
+            margin-bottom: 24px;
+        }
+        .contact-card {
+            background: #1E1E2F;
+            border: 1px solid #3a464c;
+            border-radius: 8px;
+            padding: 16px 20px;
+            margin: 16px 0;
+        }
+        .contact-card strong {
+            color: #E0C36F;
+        }
+        .faq-item {
+            margin-bottom: 18px;
+        }
+        .faq-item strong {
+            color: #F5F5F5;
+            display: block;
+            margin-bottom: 4px;
+        }
+        .faq-item p {
+            color: #c8c8d4;
+            margin: 0;
+        }
+        footer {
+            margin-top: 36px;
+            color: #6e6e80;
+            font-size: 0.85rem;
+            text-align: center;
+        }
+    </style>
+</head>
+<body>
+    <div class="container">
+        <h1>Golden Picks Support</h1>
+        <p class="lede">Need help with the Golden Picks app? We're here to help.</p>
+
+        <h2>Contact Us</h2>
+        <div class="contact-card">
+            <p><strong>Email:</strong> <a href="mailto:goldenpicks2025@gmail.com">goldenpicks2025@gmail.com</a></p>
+            <p style="margin: 0;">We typically reply within 1–2 business days.</p>
+        </div>
+
+        <h2>Frequently Asked Questions</h2>
+
+        <div class="faq-item">
+            <strong>How does Golden Picks work?</strong>
+            <p>Each Premier League gameweek you pick one team to back. Teams cost gold based on their odds — favourites cost more. You earn points based on the result: 3 for a win, 1 for a draw, 0 for a loss. Build up your score across the season and compete on global and private league leaderboards.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>How much gold do I start with?</strong>
+            <p>Every user starts the season with 400 gold. You can spend it on any team in any gameweek — but choose wisely, once it's gone, it's gone.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>What are the bonus power-ups?</strong>
+            <p><em>Double Jeopardy</em> (2 uses): Doubles the points from a pick — but also doubles the gold cost.<br>
+            <em>GD Bonus</em> (1 use): Adds the team's raw goal difference from the match to your score.<br>
+            <em>Handicap Bonus</em> (1 use): Adds +2 to your team's goal difference before scoring.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>When does my pick lock in?</strong>
+            <p>Team picks lock 30 minutes before the team's first match of the gameweek kicks off. You'll get reminder notifications 24 hours and 1 hour before lock if you haven't picked yet.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>How do private leagues work?</strong>
+            <p>Create a league with a name and password, then share those details with friends. Anyone who joins competes on a private standings table alongside the global one.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>I forgot my password.</strong>
+            <p>Tap "Forgot password" on the login screen and enter your email. We'll send a reset link valid for one hour.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>How do I delete my account?</strong>
+            <p>Email <a href="mailto:goldenpicks2025@gmail.com">goldenpicks2025@gmail.com</a> from the address registered on the account, or use the in-app account deletion option in Settings. Your data will be removed within 7 days.</p>
+        </div>
+
+        <div class="faq-item">
+            <strong>The app isn't working / I found a bug.</strong>
+            <p>Please email us with your username, device model, OS version, and a short description of the issue (a screenshot helps).</p>
+        </div>
+
+        <h2>Privacy</h2>
+        <p>We only collect the information needed to run the game: username, email, hashed password, and your picks. We never share data with third parties for advertising. Email reset and reminder messages are sent from <code>goldenpicks2025@gmail.com</code>.</p>
+
+        <footer>
+            &copy; Matthew Price-Williams — Golden Picks
+        </footer>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds `/support` route serving an HTML page with FAQ, contact email, and app overview
- Resolves App Store Review Guideline 1.5 rejection on v2.0.0 — Support URL must direct to a functional support webpage

## Test plan
- [ ] After Render deploys, visit https://premier-league-predictions-2.onrender.com/support and verify FAQ + contact info render correctly
- [ ] Update Support URL field in App Store Connect to point at this new endpoint