### PR TITLE
fix: "switch summer-test scraper to Finnish Veikkausliiga" [ci build]

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -6,12 +6,12 @@ import logging
 
 logger = logging.getLogger('golden_picks.scraper')
 
-# End of season testing on Swedish league (Allsvenskan, runs Apr–Nov) while the Premier League is off.
-# To revert: uncomment the Premier League lines and comment out the Swedish ones.
+# Summer testing on the Finnish league (Veikkausliiga) — plays through the 2026 World Cup with no fixture gaps.
+# To revert: uncomment the Premier League lines and comment out the Finnish ones.
 # LEAGUE_PATH = "england/premier-league"
 # LEAGUE_SIZE = 20
-LEAGUE_PATH = "sweden/allsvenskan"
-LEAGUE_SIZE = 16
+LEAGUE_PATH = "finland/veikkausliiga"
+LEAGUE_SIZE = 12
 FIXTURES_URL = f"https://www.betexplorer.com/football/{LEAGUE_PATH}/fixtures/"
 RESULTS_URL = f"https://www.betexplorer.com/football/{LEAGUE_PATH}/results/"
 


### PR DESCRIPTION
Switches the off-season test data source from Sweden Allsvenskan to Finland Veikkausliiga. Allsvenskan has a ~5-week World Cup gap (round 10 on 31 May → round 11 on 3 Jul); Veikkausliiga plays through the WC on a weekly cadence (rounds 10–17, 13 Jun → 26 Jul) with no multi-week gaps. LEAGUE_SIZE set to 12. Verified the scraper parses the live Finnish pages (12 teams, results + round scores).