### PR TITLE
fix: "reminder/lock timezone bug + correct reminder lead times" [ci build]

### DIFF
--- a/app.py
+++ b/app.py
@@ -423,7 +423,7 @@ def lock_team_choices():
         db.session.flush()
     db.session.commit()
 
-    new_time = datetime.now() + timedelta(days=100)
+    new_time = datetime.utcnow() + timedelta(days=100)
     teams = {}
     update_gameweek_teams(teams, new_time, None, None)
 
@@ -666,9 +666,10 @@ def keep_alive():
 
     start_time = gameweek_teams.start_time
     end_time = gameweek_teams.end_time
-    reminder_24h = start_time - pd.Timedelta(hours=24)
-    reminder_1h  = start_time - pd.Timedelta(hours=1)
-    now = datetime.now()
+    deadline = start_time - pd.Timedelta(minutes=30)   # picks lock 30 min before start
+    reminder_24h = deadline - pd.Timedelta(hours=24)
+    reminder_1h  = deadline - pd.Timedelta(hours=1)
+    now = datetime.utcnow()
 
     if now > end_time:
         try:
@@ -676,7 +677,7 @@ def keep_alive():
             if not row:
                 raise RuntimeError("Row id=1 not found")
 
-            row.end_time = datetime.now() + timedelta(days=100)
+            row.end_time = datetime.utcnow() + timedelta(days=100)
             db.session.commit()
             logger.info("End time passed — updating scores and generating new teams")
             update_scores()
@@ -686,7 +687,7 @@ def keep_alive():
             logger.error(f"keep-alive score update failed: {e}", exc_info=True)
             return f"failed updating scores: {e}", 500
 
-    if now > start_time - pd.Timedelta(minutes=30):
+    if now > deadline:
         logger.info("Lock window reached — locking team choices")
         lock_team_choices()
         return "team choices locked", 200
@@ -1180,7 +1181,7 @@ def choose_teamIOS():
     gameweek_teams = GameWeekTeams.query.first()
     if gameweek_teams and gameweek_teams.start_time:
         lock_window = gameweek_teams.start_time - timedelta(minutes=30)
-        if datetime.now() > lock_window:
+        if datetime.utcnow() > lock_window:
             return jsonify({"msg": "Deadline has passed. Picks are locked.", "deadline_passed": True}), 403
 
     if transformed_team_name == None or transformed_team_name == '':
@@ -1261,7 +1262,7 @@ def gd_bonusIOS():
     gameweek_teams = GameWeekTeams.query.first()
     if gameweek_teams and gameweek_teams.start_time:
         lock_window = gameweek_teams.start_time - timedelta(minutes=30)
-        if datetime.now() > lock_window:
+        if datetime.utcnow() > lock_window:
             return jsonify({"msg": "Deadline has passed. Picks are locked.", "deadline_passed": True}), 403
 
     user = User.query.filter_by(username=username).first()
@@ -1331,7 +1332,7 @@ def handicap_bonusIOS():
     gameweek_teams = GameWeekTeams.query.first()
     if gameweek_teams and gameweek_teams.start_time:
         lock_window = gameweek_teams.start_time - timedelta(minutes=30)
-        if datetime.now() > lock_window:
+        if datetime.utcnow() > lock_window:
             return jsonify({"msg": "Deadline has passed. Picks are locked.", "deadline_passed": True}), 403
 
     user = User.query.filter_by(username=username).first()
@@ -1393,7 +1394,7 @@ def doubleupOS():
     gameweek_teams = GameWeekTeams.query.first()
     if gameweek_teams and gameweek_teams.start_time:
         lock_window = gameweek_teams.start_time - timedelta(minutes=30)
-        if datetime.now() > lock_window:
+        if datetime.utcnow() > lock_window:
             return jsonify({"msg": "Deadline has passed. Picks are locked.", "deadline_passed": True}), 403
 
     user = User.query.filter_by(username=username).first()
@@ -1688,7 +1689,7 @@ def send_email(sender_email, sender_password, receiver_email, subject, body):
 def fetchNotificationsIOS():
     gameweek_teams = GameWeekTeams.query.first()
     start_time = gameweek_teams.start_time
-    if (start_time - timedelta(days=30)) > datetime.now():
+    if (start_time - timedelta(days=30)) > datetime.utcnow():
         start_time = None
     end_time = gameweek_teams.end_time
     next_start_time = gameweek_teams.next_start_time

--- a/scraper.py
+++ b/scraper.py
@@ -15,6 +15,18 @@ LEAGUE_SIZE = 20
 FIXTURES_URL = f"https://www.betexplorer.com/football/{LEAGUE_PATH}/fixtures/"
 RESULTS_URL = f"https://www.betexplorer.com/football/{LEAGUE_PATH}/results/"
 
+# BetExplorer renders fixture times in CET/CEST (its timezone conversion is client-side JS,
+# so a no-JS scrape always gets the European default zone). Convert to naive UTC so the
+# backend — which compares against datetime.utcnow() — gets the real kickoff times.
+SOURCE_TZ = "Europe/Berlin"
+
+def _to_utc(ts):
+    if ts is None or pd.isna(ts):
+        return ts
+    return (pd.Timestamp(ts)
+            .tz_localize(SOURCE_TZ, ambiguous=True, nonexistent="shift_forward")
+            .tz_convert("UTC").tz_localize(None).to_pydatetime())
+
 TEAM_MAPS = {"Burnley":"BUR","Sunderland":"SUN","Leeds": "LEE","Leicester": "LEI", "ManchesterCity":"MCI","Liverpool":"LIV","WestHam":"WHU","Chelsea":"CHE","Ipswich":"IPS","Arsenal":"ARS","Brentford":"BRE","CrystalPalace":"CRY","Southampton":"SOU","Tottenham":"TOT","Wolves":"WOL","AstonVilla":"AVL","Brighton":"BHA","Fulham":"FUL","Bournemouth":"BOU","Newcastle":"NEW","ManchesterUtd":"MUN","Everton":"EVE","Nottingham":"NFO"}
 
 def fetch_data_fixtures(soup, round):
@@ -85,7 +97,7 @@ def get_next_start_time(round):
 
         data['Date'] = data['Date'].apply(process_date)
         first_game = data['Date'].min() - pd.Timedelta(minutes=90)
-        return first_game
+        return _to_utc(first_game)
     except Exception as e:
         logger.error(f"get_next_start_time failed for round {round}: {e}")
         return None
@@ -104,8 +116,8 @@ def get_gameweek_teams(round):
             return {}, {}, None, None
 
         data['Date'] = data['Date'].apply(process_date)
-        first_game = data['Date'].min() - pd.Timedelta(minutes=90)
-        last_game = data['Date'].max() + pd.Timedelta(minutes=240)
+        first_game = _to_utc(data['Date'].min() - pd.Timedelta(minutes=90))
+        last_game = _to_utc(data['Date'].max() + pd.Timedelta(minutes=240))
 
         data[['home1','away1']]  = data['Match'].apply(get_teams).apply(pd.Series)
         data['home'] = data['home1'] + '_' + data['away1'] +'_H'


### PR DESCRIPTION
BetExplorer renders match times in CET/CEST (client-side JS conversion), so the no-JS scraper read them as naive and the backend compared against datetime.now() (UTC on Render) — a ~2h skew that could land the pick lock AFTER kickoff and fire reminders at the wrong wall-clock time. Fix: scraper converts kickoff times CET/CEST→UTC (DST-safe); backend uses datetime.utcnow() for all stored-time comparisons (keep-alive lock, reminders, pick/bonus deadline checks, notifications). Also corrects reminder lead times to true 24h and 1h before the pick deadline (the old "1h" was actually 30 min). deadline_utc (already Z-suffixed) is now truthful, so the app countdown is correct too.