### PR TITLE
fix: "loginIOS/scoring KeyError on non-PL teams" [ci build]

### DIFF
--- a/app.py
+++ b/app.py
@@ -449,8 +449,8 @@ def update_scores():
 
     winner_scores = get_results()
     round_scores = get_round_scores(current_round)
-    b = {REVERSE_TEAM_MAPS[i['team1']]:(points_from_GD(i['score1']-i['score2'])) for i in round_scores}
-    c = {REVERSE_TEAM_MAPS[i['team2']]:(points_from_GD(i['score2']-i['score1'])) for i in round_scores}
+    b = {REVERSE_TEAM_MAPS.get(i['team1'], i['team1']):(points_from_GD(i['score1']-i['score2'])) for i in round_scores}
+    c = {REVERSE_TEAM_MAPS.get(i['team2'], i['team2']):(points_from_GD(i['score2']-i['score1'])) for i in round_scores}
     scores_for_db = {**c,**b}
 
 
@@ -1126,7 +1126,7 @@ def loginIOS():
     token = create_access_token(identity=user.username)
 
     presented_team_choice = user.locked_team_choice if user.locked_team_choice else user.team_choice
-    presented_team_choice_out = TEAM_MAPS[presented_team_choice.split('_')[0]] if presented_team_choice else ''
+    presented_team_choice_out = TEAM_MAPS.get(presented_team_choice.split('_')[0], presented_team_choice.split('_')[0]) if presented_team_choice else ''
 
     gameweek_teams = GameWeekTeams.query.first()
     deadline = str(gameweek_teams.start_time) if gameweek_teams else ""
@@ -1226,7 +1226,7 @@ def choose_teamIOS():
             round = len(json.loads(admin.previous_results)) +1 
     
     presented_team_choice = user.locked_team_choice if user.locked_team_choice else user.team_choice
-    presented_team_choice_out = TEAM_MAPS[presented_team_choice.split('_')[0]] if presented_team_choice else ''
+    presented_team_choice_out = TEAM_MAPS.get(presented_team_choice.split('_')[0], presented_team_choice.split('_')[0]) if presented_team_choice else ''
     return jsonify({
         'access_token': "",
         'username': user.username,
@@ -1290,7 +1290,7 @@ def gd_bonusIOS():
             round = len(json.loads(admin.previous_results)) +1 
     
     presented_team_choice = user.locked_team_choice if user.locked_team_choice else user.team_choice
-    presented_team_choice_out = TEAM_MAPS[presented_team_choice.split('_')[0]] if presented_team_choice else ''
+    presented_team_choice_out = TEAM_MAPS.get(presented_team_choice.split('_')[0], presented_team_choice.split('_')[0]) if presented_team_choice else ''
     return jsonify({
         'access_token': "",
         'username': user.username,
@@ -1360,7 +1360,7 @@ def handicap_bonusIOS():
             round = len(json.loads(admin.previous_results)) +1 
     
     presented_team_choice = user.locked_team_choice if user.locked_team_choice else user.team_choice
-    presented_team_choice_out = TEAM_MAPS[presented_team_choice.split('_')[0]] if presented_team_choice else ''
+    presented_team_choice_out = TEAM_MAPS.get(presented_team_choice.split('_')[0], presented_team_choice.split('_')[0]) if presented_team_choice else ''
     return jsonify({
         'access_token': "",
         'username': user.username,
@@ -1421,7 +1421,7 @@ def doubleupOS():
             round = len(json.loads(admin.previous_results)) +1 
     
     presented_team_choice = user.locked_team_choice if user.locked_team_choice else user.team_choice
-    presented_team_choice_out = TEAM_MAPS[presented_team_choice.split('_')[0]] if presented_team_choice else ''
+    presented_team_choice_out = TEAM_MAPS.get(presented_team_choice.split('_')[0], presented_team_choice.split('_')[0]) if presented_team_choice else ''
     return jsonify({
         'access_token': "",
         'username': user.username,
@@ -1627,7 +1627,7 @@ def shorten_match_string(input_str):
     try:
         output = TEAM_MAPS[input_str]
     except KeyError:
-        output = TEAM_MAPS[0:3]
+        output = input_str[0:3]
     return output
 
 


### PR DESCRIPTION
TEAM_MAPS only contains Premier League clubs, but loginIOS (and the 4 pick/bonus endpoints) and the score-update path did hard TEAM_MAPS[...]/REVERSE_TEAM_MAPS[...] lookups on the user pick / round scores. With the summer test on Brazil Série B, a pick like "Londrina" threw KeyError → 500 on /loginIOS (the app showed it as "invalid credentials"), and scoring would crash too. Fix: use .get(name, name) fallback to the raw team name (same pattern get_round_scores already uses). Also fixes a typo in shorten_match_string (TEAM_MAPS[0:3] → input_str[0:3]).