### PR TITLE
fix: "keep-alive round advance uses .first() not hardcoded get(1)" [ci build]

### DIFF
--- a/app.py
+++ b/app.py
@@ -673,9 +673,9 @@ def keep_alive():
 
     if now > end_time:
         try:
-            row = GameWeekTeams.query.get(1)
+            row = GameWeekTeams.query.first()
             if not row:
-                raise RuntimeError("Row id=1 not found")
+                raise RuntimeError("No gameweek row found")
 
             row.end_time = datetime.utcnow() + timedelta(days=100)
             db.session.commit()


### PR DESCRIPTION
After the DB wipe (which reset ID sequences) plus repeated generate/delete cycles, the GameWeekTeams row is no longer id=1. keep-alive hardcoded GameWeekTeams.query.get(1) in the round-advance branch, so every advance threw "Row id=1 not found" → 500, and the game was permanently stuck on gameweek 11. Switch to .first() (consistent with the rest of the code).